### PR TITLE
use ParamSet when available to prevent the ownParams.$$equals exception

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/vizo/angular-ui-router-i18n.git"
   },
   "dependencies": {
-    "angular-ui-router": "= 0.2.11"
+    "angular-ui-router": ">= 0.2.18"
   },
   "ignore": [
   ],

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "angular-ui-router-i18n",
-  "version": "0.2.13",
   "main": "./i18nUrlMatcherFactory.js",
   "license": "https://github.com/vizo/angular-ui-router-i18n/blob/master/LICENSE",
   "repository": {

--- a/i18nUrlMatcherFactory.js
+++ b/i18nUrlMatcherFactory.js
@@ -13,12 +13,15 @@ function I18nUrlMatcher(patterns, config, $urlMatcherFactoryProvider) {
   this.urlMatchers = [];
   this.params = {};
   this.values = {};
-  
+
   Object.keys(patterns).forEach(function(locale) {
     var pattern = patterns[locale];
     var urlMatcher = $urlMatcherFactoryProvider.compile(pattern, config);
     this.urlMatchers[locale] = urlMatcher;
     this.params = extend({}, urlMatcher.params, this.params);
+    if (!!$urlMatcherFactoryProvider.ParamSet) {
+      this.params = new $urlMatcherFactoryProvider.ParamSet(this.params);
+    }
     if (this.rootLocale == locale) {
       this.params.rootLocale;
     }
@@ -205,7 +208,7 @@ function $I18nUrlMatcherFactory($urlMatcherFactoryProvider) {
    *
    * @description
    * Creates a {@link ui.router.util.type:UrlMatcher `UrlMatcher`} for the specified pattern.
-   *   
+   *
    * @param {string} pattern  The URL pattern.
    * @param {Object} config  The config object hash.
    * @returns {UrlMatcher}  The UrlMatcher.


### PR DESCRIPTION
Prevents `TypeError: state.ownParams.$$equals is not a function at Object.E.transitionTo` exception.
